### PR TITLE
Don't force 920px width, so you can use Vim and browser side-by-side

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags

--- a/plugin/vim-markdown-preview/stylesheets/github.css
+++ b/plugin/vim-markdown-preview/stylesheets/github.css
@@ -1,6 +1,6 @@
 body div#container {
   margin            : 0 auto;
-  width             : 920px;
+  max-width         : 920px;
   background-color  : #f8f8f8;
   padding           : .7em;
   font-size         : 13.34px;


### PR DESCRIPTION
Don't force 920px width for HTML container.

The fixed width made it difficult to use Vim and a browser side by side on smaller monitors.
