### PR TITLE
Handle spaces and quotes in the filename

### DIFF
--- a/plugin/hammer.vim/hammer.vim
+++ b/plugin/hammer.vim/hammer.vim
@@ -24,11 +24,13 @@ REQUIRE_GHMARKUP
     buffer = Vim::Buffer.current.extend Vim::ImprovedBuffer
 
     if GitHub::Markup.can_render? buffer.basename
-      File.open File.join(Hammer::ENV.directory, "#{buffer.basename}.html"), 'w' do |f|
+      output_path = File.join Hammer::ENV.directory, "#{buffer.basename}.html"
+
+      File.open output_path, 'w' do |f|
         f.write Hammer.render { GitHub::Markup.render(buffer.basename, buffer[1..-1]) }
       end
 
-      Vim.command "silent ! #{Hammer::ENV.browser} #{File.join Hammer::ENV.directory, buffer.basename}.html"
+      Vim.command "silent ! #{Hammer::ENV.browser} #{output_path.inspect}"
       Vim.command "redraw!"
     elsif buffer.extname =~ /^\.(xhtml|html)$/
       Vim.command "silent ! #{Hammer::ENV.browser} #{buffer.name}"

--- a/plugin/hammer.vim/hammer.vim
+++ b/plugin/hammer.vim/hammer.vim
@@ -7,6 +7,7 @@ if has('ruby')
   ruby require 'lib/hammer/env'
   ruby require 'lib/vim/improvedbuffer'
   ruby require 'erb'
+  ruby require 'shellwords'
   ruby << REQUIRE_GHMARKUP
   begin
     require 'github/markup'
@@ -30,10 +31,10 @@ REQUIRE_GHMARKUP
         f.write Hammer.render { GitHub::Markup.render(buffer.basename, buffer[1..-1]) }
       end
 
-      Vim.command "silent ! #{Hammer::ENV.browser} #{output_path.inspect}"
+      Vim.command "silent ! #{Shellwords.escape Hammer::ENV.browser} #{Shellwords.escape output_path}"
       Vim.command "redraw!"
     elsif buffer.extname =~ /^\.(xhtml|html)$/
-      Vim.command "silent ! #{Hammer::ENV.browser} #{buffer.name}"
+      Vim.command "silent ! #{Shellwords.escape Hammer::ENV.browser} #{Shellwords.escape buffer.name}"
       Vim.command "redraw!"
     else
       Vim.message "It is not possible to render #{buffer.extname} files. Missing dependency?" 

--- a/plugin/hammer.vim/hammer.vim
+++ b/plugin/hammer.vim/hammer.vim
@@ -24,6 +24,11 @@ REQUIRE_GHMARKUP
   ruby << RUBY
     buffer = Vim::Buffer.current.extend Vim::ImprovedBuffer
 
+    def open_browser(output_path)
+      Vim.command "silent ! #{Shellwords.escape Hammer::ENV.browser} #{Shellwords.escape output_path}"
+      Vim.command "redraw!"
+    end
+
     if GitHub::Markup.can_render? buffer.basename
       output_path = File.join Hammer::ENV.directory, "#{buffer.basename}.html"
 
@@ -31,11 +36,9 @@ REQUIRE_GHMARKUP
         f.write Hammer.render { GitHub::Markup.render(buffer.basename, buffer[1..-1]) }
       end
 
-      Vim.command "silent ! #{Shellwords.escape Hammer::ENV.browser} #{Shellwords.escape output_path}"
-      Vim.command "redraw!"
+      open_browser output_path
     elsif buffer.extname =~ /^\.(xhtml|html)$/
-      Vim.command "silent ! #{Shellwords.escape Hammer::ENV.browser} #{Shellwords.escape buffer.name}"
-      Vim.command "redraw!"
+      open_browser buffer.name
     else
       Vim.message "It is not possible to render #{buffer.extname} files. Missing dependency?" 
     end


### PR DESCRIPTION
Spaces or quotes in a filename would silently do nothing. Calling `#inspect` on the output path fixes the few scenarios I tested.
