### PR TITLE
Default template with inline css

### DIFF
--- a/plugin/hammer.vim/templates/default_inline.html.erb
+++ b/plugin/hammer.vim/templates/default_inline.html.erb
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <style type="text/css">
+        body div#content
+        {
+          margin            : 0 auto;
+          max-width         : 920px;
+          background-color  : #f8f8f8;
+          padding           : .7em;
+          font-size         : 13.34px;
+          font-family       : verdana, sans-serif;
+          border            : 1px #E0E0E0 solid;
+        }
+
+        body div#content h2, body div#content h3, body div#content h4
+        {
+          padding-top  : 10px;
+          border-top   : 4px solid #E0E0E0;
+        }
+
+        body div#content pre
+        {
+          padding          : 5px;
+          border-style     : solid;
+          border-width     : 1px;
+          border-color     : #E0E0E0;
+          background-color : #F8F8FF;
+        }
+
+        body div#content pre code
+        {
+          padding          : 5px;
+          background-color : #F8F8FF;
+          border           : none;
+        }
+
+        body div#content code
+        {
+          font-family      : courier, fixed;
+          display          : inline-block;
+          padding          : 0px 2px 0px 2px;
+          background-color : #F8F8FF;
+          border           : 1px #E0E0E0 solid;
+        }
+    </style>
+    <title> Preview </title>
+  </head>
+
+  <body>
+    <div id="content">
+      <%= yield %>
+    </div>
+  </body>
+
+</html>
+


### PR DESCRIPTION
I added a copy of the default template with inline css. This is nice when saving the generated HTML for distribution because there are no externals assets.
