### PR TITLE
Small fix to stop VIM from throwing errors when there's no ruby built in.

### DIFF
--- a/plugin/hammer.vim/bootstrap.vim
+++ b/plugin/hammer.vim/bootstrap.vim
@@ -31,12 +31,12 @@ if !exists('g:HAMMER_TEMPLATE')
   let g:HAMMER_TEMPLATE = 'default'
 endif
 
-ruby $: << File.join(Vim.evaluate('g:HAMMER_INSTALL_PATH'), 'lib') 
-ruby require 'hammer'
-ruby Hammer.load_dependencies! 
-ruby Hammer.load_renderers!
-
 if has('ruby')
+  ruby $: << File.join(Vim.evaluate('g:HAMMER_INSTALL_PATH'), 'lib') 
+  ruby require 'hammer'
+  ruby Hammer.load_dependencies! 
+  ruby Hammer.load_renderers!
+
   function! Hammer()
     ruby <<RENDER!
       buffer = Vim::Buffer.current.extend Vim::ImprovedBuffer


### PR DESCRIPTION
Details of the change:
- The bootstrap kicked off in the console version of VIM and
  was throwing errors because the console version doesn't have
  ruby support. This is on Mac OSX with MacVim and plugin was
  activated via pathogen.
- I modified the bootstrap so that the ruby check is done prior
  to any ruby commands, and hence the plugin no longer throws
  errors in the console when it starts up.
