### PR TITLE
Add ability to create/update the preview without bringing the browser to the foreground.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ __CONFIG VARIABLES__
   The template to use.  
   Defaults to 'default', a GitHub-esque README template.
 
+* g:HAMMER\_BROWSER\_ARGS
+  Optional arguments to pass to the `browser` command.  On OS X, it can be useful
+  to set this to '-g' to open the browser window in the background.
+
 __INSTALL__
 
 You may need to install other dependencies for your markup language (See Above)  

--- a/plugin/hammer.vim/bootstrap.vim
+++ b/plugin/hammer.vim/bootstrap.vim
@@ -27,6 +27,10 @@ if !exists('g:HAMMER_BROWSER')
   end
 endif
 
+if !exists('g:HAMMER_BROWSER_ARGS')
+  let g:HAMMER_BROWSER_ARGS = ''
+endif
+
 if !exists('g:HAMMER_TEMPLATE')
   let g:HAMMER_TEMPLATE = 'default'
 endif

--- a/plugin/hammer.vim/lib/hammer.rb
+++ b/plugin/hammer.vim/lib/hammer.rb
@@ -83,9 +83,10 @@ module Hammer
     #
     def open_browser path
       browser_path = Shellwords.escape(Hammer::ENV.browser)
+      browser_args = Hammer::ENV.browser_args
       file_path    = Shellwords.escape(path)
 
-      Vim.command "silent ! #{browser_path} #{file_path}"
+      Vim.command "silent ! #{browser_path} #{browser_args} #{file_path}"
       Vim.command "redraw!"
     end
 

--- a/plugin/hammer.vim/lib/hammer/env.rb
+++ b/plugin/hammer.vim/lib/hammer/env.rb
@@ -18,6 +18,10 @@ module Hammer::ENV
       @browser = Vim.evaluate 'g:HAMMER_BROWSER'
     end
 
+    def browser_args
+      @browser_args = Vim.evaluate 'g:HAMMER_BROWSER_ARGS'
+    end
+
     def commands_path
       @commands_path ||= File.join(install_path, "commands")
     end


### PR DESCRIPTION
I tried just setting g:HAMMER_BROWSER to 'open -g', but the shell escaping (I think) made that not work.  So, instead I just added a new g:HAMMER_BROWSER_ARGS variable, which can be set to '-g' on OS X to tell `open` to not bring the browser to the foreground.

This is useful if you do something like:
    :au BufWrite \* Hammer
when editing a markdown file, because it will auto-update the preview every time you save.
