### PR TITLE
Fix rendering of .html|.xhtml files on Linux (Fixes #50)

### DIFF
--- a/autoload/hammer.vim
+++ b/autoload/hammer.vim
@@ -24,6 +24,19 @@ if has('ruby')
     end
   endif
 
+  if !exists('g:HAMMER_CAT')
+    if has('mac')
+      let g:HAMMER_CAT = 'cat'
+    elseif has('win32') || has('win64')
+      let g:HAMMER_CAT = 'type'
+  elseif has('unix') && executable('cat')
+      let g:HAMMER_CAT = 'cat'
+    else
+      let g:HAMMER_CAT = ''
+    end
+  endif
+
+
   if !exists('g:HAMMER_BROWSER_ARGS')
     let g:HAMMER_BROWSER_ARGS = ''
   endif

--- a/plugin/hammer.vim/lib/hammer/env.rb
+++ b/plugin/hammer.vim/lib/hammer/env.rb
@@ -22,6 +22,10 @@ module Hammer::ENV
       @browser_args = Vim.evaluate 'g:HAMMER_BROWSER_ARGS'
     end
 
+    def catcmd
+      @catcmd = Vim.evaluate 'g:HAMMER_CAT'
+    end
+
     def commands_path
       @commands_path ||= File.join(install_path, "commands")
     end

--- a/plugin/hammer.vim/renderers/html_renderer.rb
+++ b/plugin/hammer.vim/renderers/html_renderer.rb
@@ -1,1 +1,1 @@
-command Hammer::ENV.browser, /html|xhtml/
+command Hammer::ENV.catcmd, /html|xhtml/


### PR DESCRIPTION
- Use OS cat command to simply output file to STDOUT so tilt can render it
