### PR TITLE
Use vim :TOhtml as fallback renderer

### DIFF
--- a/autoload/hammer.vim
+++ b/autoload/hammer.vim
@@ -24,6 +24,19 @@ if has('ruby')
     end
   endif
 
+  if !exists('g:HAMMER_CAT')
+    if has('mac')
+      let g:HAMMER_CAT = 'cat'
+    elseif has('win32') || has('win64')
+      let g:HAMMER_CAT = 'type'
+  elseif has('unix') && executable('cat')
+      let g:HAMMER_CAT = 'cat'
+    else
+      let g:HAMMER_CAT = ''
+    end
+  endif
+
+
   if !exists('g:HAMMER_BROWSER_ARGS')
     let g:HAMMER_BROWSER_ARGS = ''
   endif

--- a/plugin/hammer.vim/lib/hammer/env.rb
+++ b/plugin/hammer.vim/lib/hammer/env.rb
@@ -22,6 +22,10 @@ module Hammer::ENV
       @browser_args = Vim.evaluate 'g:HAMMER_BROWSER_ARGS'
     end
 
+    def catcmd
+      @catcmd = Vim.evaluate 'g:HAMMER_CAT'
+    end
+
     def commands_path
       @commands_path ||= File.join(install_path, "commands")
     end

--- a/plugin/hammer.vim/renderers/html_renderer.rb
+++ b/plugin/hammer.vim/renderers/html_renderer.rb
@@ -1,1 +1,1 @@
-command Hammer::ENV.browser, /html|xhtml/
+command Hammer::ENV.catcmd, /html|xhtml/


### PR DESCRIPTION
In the case where `GitHub::Markup` cannot render a given filetype, it would be good to use vim's built-in `:TOhtml` command instead.   This gives us the added capability of rendering _any_ unrecognized file using vim's syntax highlighting!

The check for this capability should be really safe, as it is the same as used in the [TOhtml plugin itself](http://vim.cybermirror.org/runtime/plugin/tohtml.vim). (This also depends on my Pull Request #51 to work on Linux)
# Screenshot

![vim-Hammer-TOhtml-Screenshot](https://f.cloud.github.com/assets/122524/94681/98eed91a-6653-11e2-9860-23f81dee2602.png)
